### PR TITLE
Apply workaround to prevent blur over margins

### DIFF
--- a/lib/src/pages/botones_page.dart
+++ b/lib/src/pages/botones_page.dart
@@ -161,33 +161,43 @@ class BotonesPage extends StatelessWidget {
   Widget _crearBotonRedondeado( Color color, IconData icono, String texto ) {
  
  
-    return ClipRect(
-      child: BackdropFilter(
-        filter: ImageFilter.blur( sigmaX: 10.0, sigmaY: 10.0 ),
-        child: Container(
-          height: 180.0,
-          margin: EdgeInsets.all(15.0),
-          decoration: BoxDecoration(
-            color: Color.fromRGBO(62, 66, 107, 0.7),
-            borderRadius: BorderRadius.circular(20.0)
-          ),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: <Widget>[
-              SizedBox( height: 5.0 ),
-              CircleAvatar(
-                backgroundColor: color,
-                radius: 35.0,
-                child: Icon( icono, color: Colors.white, size: 30.0 ),
+    //Your course is amazing, thanks for it
+    return Padding(
+      padding: EdgeInsets.all(15.0),
+      child: Container(
+        clipBehavior: Clip.antiAlias,
+        decoration: BoxDecoration(
+          // color: Colors.red,
+          borderRadius: BorderRadius.circular(20.0)
+        ),
+        child: ClipRect(
+          child: BackdropFilter(
+            filter: ImageFilter.blur( sigmaX: 10.0, sigmaY: 10.0 ),
+            child: Container(
+              height: 180.0,
+              // margin: EdgeInsets.all(15.0),
+              decoration: BoxDecoration(
+                color: Color.fromRGBO(62, 66, 107, 0.7),
+                borderRadius: BorderRadius.circular(20.0)
               ),
-              Text( texto , style: TextStyle( color: color )),
-              SizedBox( height: 5.0 )
-            ],
-          ),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: <Widget>[
+                  CircleAvatar(
+                    backgroundColor: Colors.pinkAccent,
+                    radius: 35.0,
+                    child: Icon(Icons.swap_calls, color: Colors.white, size: 30.0,),
+                  ),
+                  Text("thing", style: TextStyle(color: Colors.pinkAccent),)
+                ],
+              ),
  
+            ),
+          ),
         ),
       ),
     );
+
   }
 
 


### PR DESCRIPTION
Estaba siguiendo tu curso, en una versión antigua de cuando todavía no le habías agregado el ClipRect al BackdropFilter y se me aplicó el blur a toda la app 😅. Por suerte encontré tu repo y lo vi arreglado

Quise arreglarlo un poco, con respecto al blur que se expande sobre el margin de cada botón y gracias lo que habías hecho anteriormente en el módulo de componentes, lo logré.

Aquí te dejo PR